### PR TITLE
ci: install Terraform CLI in generate job to fix doc generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
       - run: go generate ./...
       - name: git diff
         run: |


### PR DESCRIPTION
The tfplugindocs tool downloads Terraform CLI to export the provider schema, but the embedded HashiCorp GPG key used to verify the download has expired upstream, causing every PR's "generate" check to fail with "openpgp: key expired".                                                                                                               

Adding hashicorp/setup-terraform puts the binary on PATH so tfplugindocs uses it directly and skips the broken download.