### PR TITLE
[CLA-1607] FIX: poll Bunny pull zone on create to ensure CNAME value is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes of the StatusPal Terraform provider will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-05-06
+
+### Fixed
+
+- Bunny custom domain provisioning now works in a single `terraform apply`. The
+  provider polls the API until the Bunny pull zone is ready and the CNAME value
+  is available, instead of returning an empty value that caused DNS record
+  creation to fail.
+
 ## [0.4.1] - 2026-05-04
 
 ### Fixed

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     statuspal = {
       source  = "statuspal/statuspal"
-      version = "0.4.1"
+      version = "0.4.2"
     }
   }
 

--- a/docs/resources/custom_domain_validation.md
+++ b/docs/resources/custom_domain_validation.md
@@ -15,9 +15,11 @@ Waiter resource that blocks until a status page's custom domain reaches the "act
 ```terraform
 # Waiter resource that polls until a status page's custom domain reaches
 # "active" status. Use this as the final step in a custom domain setup to
-# confirm the domain is fully configured before proceeding. See
-# https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain
-# for the full end-to-end flow.
+# confirm the domain is fully configured before proceeding.
+#
+# This resource works with both Cloudflare and Bunny custom domains. See:
+# - Cloudflare: https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain
+# - Bunny:      https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain_bunny
 
 resource "statuspal_custom_domain_validation" "example" {
   organization_id       = "1"

--- a/docs/resources/domain_ssl_records.md
+++ b/docs/resources/domain_ssl_records.md
@@ -3,12 +3,14 @@
 page_title: "statuspal_domain_ssl_records Resource - statuspal"
 subcategory: ""
 description: |-
-  Waiter resource that polls a status page's domain_config until the SSL certificate challenge DNS records become available, then exposes them as computed attributes. Use this between creating the CNAME routing record and the TXT certificate record to enable a single-apply custom domain flow. Destroying this resource is a no-op.
+  Waiter resource that polls a status page's domain_config until the SSL certificate challenge DNS records become available, then exposes them as computed attributes. Use this between creating the CNAME routing record and the TXT certificate record to enable a single-apply custom domain flow. Destroying this resource is a no-op. **This resource is only needed for Cloudflare custom domains.** Bunny CDN handles SSL automatically and does not require certificate challenge records — see the [Bunny example](https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain_bunny) for the simpler flow.
 ---
 
 # statuspal_domain_ssl_records (Resource)
 
 Waiter resource that polls a status page's domain_config until the SSL certificate challenge DNS records become available, then exposes them as computed attributes. Use this between creating the CNAME routing record and the TXT certificate record to enable a single-apply custom domain flow. Destroying this resource is a no-op.
+
+~> **Note:** This resource is only needed for **Cloudflare** custom domains. Bunny CDN handles SSL automatically and does not require certificate challenge records. See the [Bunny custom domain example](https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain_bunny) for the simpler flow.
 
 ## Example Usage
 
@@ -16,10 +18,11 @@ Waiter resource that polls a status page's domain_config until the SSL certifica
 # Waiter resource that polls until the SSL certificate DNS challenge records
 # are available for a status page with a custom domain configured via Cloudflare.
 #
-# Use this between creating the CNAME routing record and the TXT certificate
-# record to complete custom domain setup in a single terraform apply. See
-# https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain
-# for the full end-to-end flow.
+# This resource is NOT needed for Bunny custom domains — Bunny handles SSL
+# automatically. Use this between creating the CNAME routing record and the
+# TXT certificate record to complete custom domain setup in a single terraform
+# apply. See https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain
+# for the full Cloudflare end-to-end flow.
 
 resource "statuspal_domain_ssl_records" "example" {
   organization_id       = "1"

--- a/docs/resources/domain_ssl_records.md
+++ b/docs/resources/domain_ssl_records.md
@@ -3,14 +3,12 @@
 page_title: "statuspal_domain_ssl_records Resource - statuspal"
 subcategory: ""
 description: |-
-  Waiter resource that polls a status page's domain_config until the SSL certificate challenge DNS records become available, then exposes them as computed attributes. Use this between creating the CNAME routing record and the TXT certificate record to enable a single-apply custom domain flow. Destroying this resource is a no-op. **This resource is only needed for Cloudflare custom domains.** Bunny CDN handles SSL automatically and does not require certificate challenge records — see the [Bunny example](https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain_bunny) for the simpler flow.
+  Waiter resource that polls a status page's domain_config until the SSL certificate challenge DNS records become available, then exposes them as computed attributes. Use this between creating the CNAME routing record and the TXT certificate record to enable a single-apply custom domain flow. Destroying this resource is a no-op. This resource is only needed for Cloudflare custom domains — Bunny handles SSL automatically.
 ---
 
 # statuspal_domain_ssl_records (Resource)
 
-Waiter resource that polls a status page's domain_config until the SSL certificate challenge DNS records become available, then exposes them as computed attributes. Use this between creating the CNAME routing record and the TXT certificate record to enable a single-apply custom domain flow. Destroying this resource is a no-op.
-
-~> **Note:** This resource is only needed for **Cloudflare** custom domains. Bunny CDN handles SSL automatically and does not require certificate challenge records. See the [Bunny custom domain example](https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain_bunny) for the simpler flow.
+Waiter resource that polls a status page's domain_config until the SSL certificate challenge DNS records become available, then exposes them as computed attributes. Use this between creating the CNAME routing record and the TXT certificate record to enable a single-apply custom domain flow. Destroying this resource is a no-op. This resource is only needed for Cloudflare custom domains — Bunny handles SSL automatically.
 
 ## Example Usage
 

--- a/docs/resources/status_page.md
+++ b/docs/resources/status_page.md
@@ -28,15 +28,34 @@ resource "statuspal_status_page" "example" {
 # for the full single-apply flow that wires domain_config together with the
 # statuspal_domain_ssl_records and statuspal_custom_domain_validation waiter
 # resources plus the corresponding cloudflare_record entries.
-resource "statuspal_status_page" "with_custom_domain" {
+resource "statuspal_status_page" "with_cloudflare_domain" {
   organization_id = "1"
   status_page = {
-    name      = "Status Page with Custom Domain"
+    name      = "Status Page with Cloudflare Domain"
     url       = "example.com"
     time_zone = "UTC"
 
     domain_config = {
       provider = "cloudflare"
+      domain   = "status.example.com"
+    }
+  }
+}
+
+# Status page with a custom domain provisioned via Bunny CDN.
+# Bunny handles SSL automatically, so the flow is simpler: no
+# statuspal_domain_ssl_records or TXT record is needed.
+# See https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain_bunny
+# for the full single-apply flow.
+resource "statuspal_status_page" "with_bunny_domain" {
+  organization_id = "1"
+  status_page = {
+    name      = "Status Page with Bunny Domain"
+    url       = "example.com"
+    time_zone = "UTC"
+
+    domain_config = {
+      provider = "bunny"
       domain   = "status.example.com"
     }
   }

--- a/examples/custom_domain_bunny/main.tf
+++ b/examples/custom_domain_bunny/main.tf
@@ -1,0 +1,77 @@
+terraform {
+  required_providers {
+    statuspal = {
+      source = "registry.terraform.io/statuspal/statuspal"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = ">= 1.4.0"
+}
+
+provider "statuspal" {
+  api_key = var.statuspal_api_key
+  region  = "EU"
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+variable "statuspal_api_key" {
+  sensitive = true
+}
+
+variable "cloudflare_api_token" {
+  sensitive = true
+}
+
+variable "cloudflare_zone_id" {}
+
+variable "org_id" {}
+
+# Step 1 — Create the status page with domain_config using Bunny CDN.
+# The provider polls until the Bunny pull zone is ready and the CNAME value
+# is available, so validation_records["cname"] is populated after this step.
+resource "statuspal_status_page" "main" {
+  organization_id = var.org_id
+  status_page = {
+    name      = "Acme Status"
+    url       = "https://status.acme.com"
+    time_zone = "UTC"
+    subdomain = "acme"
+
+    domain_config = {
+      provider = "bunny"
+      domain   = "status.acme.com"
+    }
+  }
+}
+
+# Step 2 — CNAME record to route the custom domain to the Bunny CDN hostname.
+resource "cloudflare_record" "cname" {
+  zone_id = var.cloudflare_zone_id
+  name    = statuspal_status_page.main.status_page.domain_config.validation_records["cname"].name
+  type    = "CNAME"
+  content = statuspal_status_page.main.status_page.domain_config.validation_records["cname"].value
+  proxied = false
+  ttl     = 120
+}
+
+# Step 3 — Wait until the custom domain is fully active.
+# Bunny handles SSL automatically — no statuspal_domain_ssl_records or TXT
+# record is needed (unlike the Cloudflare flow).
+resource "statuspal_custom_domain_validation" "main" {
+  organization_id       = var.org_id
+  status_page_subdomain = statuspal_status_page.main.status_page.subdomain
+  timeout_seconds       = 600
+
+  depends_on = [cloudflare_record.cname]
+}
+
+output "domain_status" {
+  value = statuspal_status_page.main.status_page.domain_config.status
+}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     statuspal = {
       source  = "statuspal/statuspal"
-      version = "0.4.1"
+      version = "0.4.2"
     }
   }
 

--- a/examples/resources/statuspal_custom_domain_validation/resource.tf
+++ b/examples/resources/statuspal_custom_domain_validation/resource.tf
@@ -1,8 +1,10 @@
 # Waiter resource that polls until a status page's custom domain reaches
 # "active" status. Use this as the final step in a custom domain setup to
-# confirm the domain is fully configured before proceeding. See
-# https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain
-# for the full end-to-end flow.
+# confirm the domain is fully configured before proceeding.
+#
+# This resource works with both Cloudflare and Bunny custom domains. See:
+# - Cloudflare: https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain
+# - Bunny:      https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain_bunny
 
 resource "statuspal_custom_domain_validation" "example" {
   organization_id       = "1"

--- a/examples/resources/statuspal_domain_ssl_records/resource.tf
+++ b/examples/resources/statuspal_domain_ssl_records/resource.tf
@@ -1,10 +1,11 @@
 # Waiter resource that polls until the SSL certificate DNS challenge records
 # are available for a status page with a custom domain configured via Cloudflare.
 #
-# Use this between creating the CNAME routing record and the TXT certificate
-# record to complete custom domain setup in a single terraform apply. See
-# https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain
-# for the full end-to-end flow.
+# This resource is NOT needed for Bunny custom domains — Bunny handles SSL
+# automatically. Use this between creating the CNAME routing record and the
+# TXT certificate record to complete custom domain setup in a single terraform
+# apply. See https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain
+# for the full Cloudflare end-to-end flow.
 
 resource "statuspal_domain_ssl_records" "example" {
   organization_id       = "1"

--- a/examples/resources/statuspal_status_page/resource.tf
+++ b/examples/resources/statuspal_status_page/resource.tf
@@ -13,15 +13,34 @@ resource "statuspal_status_page" "example" {
 # for the full single-apply flow that wires domain_config together with the
 # statuspal_domain_ssl_records and statuspal_custom_domain_validation waiter
 # resources plus the corresponding cloudflare_record entries.
-resource "statuspal_status_page" "with_custom_domain" {
+resource "statuspal_status_page" "with_cloudflare_domain" {
   organization_id = "1"
   status_page = {
-    name      = "Status Page with Custom Domain"
+    name      = "Status Page with Cloudflare Domain"
     url       = "example.com"
     time_zone = "UTC"
 
     domain_config = {
       provider = "cloudflare"
+      domain   = "status.example.com"
+    }
+  }
+}
+
+# Status page with a custom domain provisioned via Bunny CDN.
+# Bunny handles SSL automatically, so the flow is simpler: no
+# statuspal_domain_ssl_records or TXT record is needed.
+# See https://github.com/statuspal/terraform-provider-statuspal/tree/main/examples/custom_domain_bunny
+# for the full single-apply flow.
+resource "statuspal_status_page" "with_bunny_domain" {
+  organization_id = "1"
+  status_page = {
+    name      = "Status Page with Bunny Domain"
+    url       = "example.com"
+    time_zone = "UTC"
+
+    domain_config = {
+      provider = "bunny"
       domain   = "status.example.com"
     }
   }

--- a/internal/provider/domain_ssl_records_resource.go
+++ b/internal/provider/domain_ssl_records_resource.go
@@ -55,7 +55,8 @@ func (r *domainSslRecordsResource) Schema(_ context.Context, _ resource.SchemaRe
 		Description: "Waiter resource that polls a status page's domain_config until the SSL certificate " +
 			"challenge DNS records become available, then exposes them as computed attributes. " +
 			"Use this between creating the CNAME routing record and the TXT certificate record " +
-			"to enable a single-apply custom domain flow. Destroying this resource is a no-op.",
+			"to enable a single-apply custom domain flow. Destroying this resource is a no-op. " +
+			"This resource is only needed for Cloudflare custom domains — Bunny handles SSL automatically.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Placeholder identifier attribute.",

--- a/internal/provider/status_page_resource.go
+++ b/internal/provider/status_page_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -755,6 +756,19 @@ func (r *statusPageResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
+	// Bunny pull zone creation is asynchronous — poll until the CNAME value is available.
+	if newStatusPage.DomainConfig != nil && newStatusPage.DomainConfig.CDNProvider != nil &&
+		strings.ToLower(*newStatusPage.DomainConfig.CDNProvider) == "bunny" {
+		newStatusPage, err = pollBunnyValidationRecords(r.client, organizationID, newStatusPage.Subdomain, 60*time.Second)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error waiting for Bunny pull zone",
+				"Bunny pull zone creation did not complete: "+err.Error(),
+			)
+			return
+		}
+	}
+
 	// Map response body to schema and populate Computed attribute values
 	newStatusPageModel := mapResponseToStatusPageModel(newStatusPage, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -868,6 +882,23 @@ func (r *statusPageResource) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	// Bunny pull zone creation is asynchronous — poll until the CNAME value is available.
+	if updatedStatusPage.DomainConfig != nil && updatedStatusPage.DomainConfig.CDNProvider != nil &&
+		strings.ToLower(*updatedStatusPage.DomainConfig.CDNProvider) == "bunny" {
+		updatedSubdomain := updatedStatusPage.Subdomain
+		if updatedSubdomain == "" {
+			updatedSubdomain = subdomain
+		}
+		updatedStatusPage, err = pollBunnyValidationRecords(r.client, organizationID, updatedSubdomain, 60*time.Second)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Error waiting for Bunny pull zone",
+				"Bunny pull zone creation did not complete: "+err.Error(),
+			)
+			return
+		}
+	}
+
 	// Map response body to schema and populate Computed attribute values
 	updatedStatusPageModel := mapResponseToStatusPageModel(updatedStatusPage, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
@@ -979,6 +1010,42 @@ func needsLegacyDomainClear(ctx *context.Context, stateStatusPage *statusPageMod
 
 	return stateProvider == "legacy_custom_domain" &&
 		(plannedProvider == "cloudflare" || plannedProvider == "bunny")
+}
+
+// pollBunnyValidationRecords polls GetStatusPage until the Bunny pull zone is
+// configured and the CNAME value is populated. Bunny pull zone creation is
+// asynchronous, so the initial response may have an empty CNAME value.
+func pollBunnyValidationRecords(
+	client *statuspal.Client,
+	orgID, subdomain string,
+	timeout time.Duration,
+) (*statuspal.StatusPage, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		sp, err := client.GetStatusPage(&orgID, &subdomain)
+		if err != nil {
+			return nil, err
+		}
+		if sp.DomainConfig == nil {
+			return sp, nil
+		}
+		status := ""
+		if sp.DomainConfig.Status != nil {
+			status = *sp.DomainConfig.Status
+		}
+		if status == "failed_to_configure" {
+			return sp, nil
+		}
+		if vr := sp.DomainConfig.ValidationRecords; vr != nil {
+			if v, ok := vr["hostname_cname_value"]; ok && v != "" {
+				return sp, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return sp, fmt.Errorf("timed out waiting for Bunny pull zone CNAME value after %s", timeout)
+		}
+		time.Sleep(2 * time.Second)
+	}
 }
 
 func mapStatusPageModelToRequestBody(

--- a/internal/provider/status_page_resource_test.go
+++ b/internal/provider/status_page_resource_test.go
@@ -822,3 +822,174 @@ func TestAccStatusPageResource_LegacyToCloudFlareMigration(t *testing.T) {
 		},
 	})
 }
+
+// TestAccStatusPageResource_BunnyDomain verifies that creating a status page with
+// provider="bunny" polls until the CNAME value is populated (Bunny pull zone
+// creation is asynchronous) and stores the correct validation records in state.
+func TestAccStatusPageResource_BunnyDomain(t *testing.T) {
+	var pollCount atomic.Int32
+
+	bunnyResponseNoCNAME := `{
+		"status_page": {
+			"name": "Bunny Domain Test",
+			"url": "bunny.test",
+			"time_zone": "UTC",
+			"subdomain": "bunny-test",
+			"domain": "bunny-test.example.com",
+			"custom_domain_enabled": true,
+			"domain_config": {
+				"provider": "bunny",
+				"domain": "bunny-test.example.com",
+				"main_hostname": null,
+				"status": "configuring",
+				"error": null,
+				"external_id": null,
+				"pullzone_id": null,
+				"validation_records": {
+					"hostname_cname_name": "bunny-test.example.com",
+					"hostname_cname_value": ""
+				}
+			},
+			"theme_selected": "default",
+			"scheduled_maintenance_days": 7,
+			"display_uptime_graph": true,
+			"inserted_at": "2024-06-01T10:00:00",
+			"updated_at": "2024-06-01T10:00:00",
+			"header_fg_color": "ffffff",
+			"history_limit_days": 90,
+			"head_code": null,
+			"support_email": null,
+			"locked_when_maintenance": false,
+			"custom_footer": null,
+			"custom_incident_types_enabled": false,
+			"slack_subscriptions_enabled": false,
+			"date_format": null,
+			"maintenance_notification_hours": 6,
+			"twitter_public_screen_name": null,
+			"header_logo_text": null,
+			"member_restricted": false,
+			"status_ok_color": "48CBA5",
+			"uptime_graph_days": 90,
+			"subscribers_enabled": true,
+			"display_about": false,
+			"translations": {},
+			"tweet_by_default": false,
+			"display_calendar": true,
+			"email_templates_enabled": false,
+			"google_calendar_enabled": false,
+			"link_color": "0c91c3",
+			"email_layout_template": null,
+			"status_major_color": "e75a53",
+			"custom_header": null,
+			"date_format_enforce_everywhere": false,
+			"time_format": null,
+			"header_bg_color1": "009688",
+			"incident_link_color": null,
+			"bg_image": null,
+			"logo": null,
+			"favicon": null,
+			"custom_css": null,
+			"current_incidents_position": "below_services",
+			"custom_js": null,
+			"minor_notification_hours": 6,
+			"mattermost_notifications_enabled": false,
+			"info_notices_enabled": true,
+			"captcha_enabled": true,
+			"about": null,
+			"google_chat_notifications_enabled": false,
+			"discord_notifications_enabled": false,
+			"status_minor_color": "FFA500",
+			"tweeting_enabled": true,
+			"sms_notifications_enabled": false,
+			"zoom_notifications_enabled": false,
+			"notify_by_default": false,
+			"hide_watermark": false,
+			"enable_auto_translations": false,
+			"restricted_ips": null,
+			"feed_enabled": true,
+			"header_bg_color2": "0c91c3",
+			"public_company_name": null,
+			"notification_email": null,
+			"email_notification_template": null,
+			"teams_notifications_enabled": false,
+			"status_maintenance_color": "5378c1",
+			"email_confirmation_template": null,
+			"calendar_enabled": false,
+			"major_notification_hours": 3,
+			"incident_header_color": "009688",
+			"reply_to_email": null,
+			"noindex": false,
+			"allowed_email_domains": null
+		}
+	}`
+
+	bunnyResponseWithCNAME := strings.Replace(bunnyResponseNoCNAME,
+		`"hostname_cname_value": ""`,
+		`"hostname_cname_value": "statuspal-eu-12345.b-cdn.net"`, 1)
+	bunnyResponseWithCNAME = strings.Replace(bunnyResponseWithCNAME,
+		`"main_hostname": null`,
+		`"main_hostname": "statuspal-eu-12345.b-cdn.net"`, 1)
+	bunnyResponseWithCNAME = strings.Replace(bunnyResponseWithCNAME,
+		`"pullzone_id": null`,
+		`"pullzone_id": 12345`, 1)
+	bunnyResponseWithCNAME = strings.Replace(bunnyResponseWithCNAME,
+		`"external_id": null`,
+		`"external_id": "bunny-test.example.com"`, 1)
+
+	mux := http.NewServeMux()
+
+	// POST /orgs/1/status_pages — returns response without CNAME value (pull zone not ready)
+	mux.HandleFunc("/orgs/1/status_pages", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(bunnyResponseNoCNAME))
+	})
+	// GET/PUT/DELETE /orgs/1/status_pages/bunny-test — simulates async pull zone creation
+	mux.HandleFunc("/orgs/1/status_pages/bunny-test", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			_, _ = w.Write([]byte(`""`))
+			return
+		}
+		if r.Method == http.MethodGet {
+			pollCount.Add(1)
+		}
+		// Always return the populated response for GET/PUT (simulates pull zone ready after first poll)
+		_, _ = w.Write([]byte(bunnyResponseWithCNAME))
+	})
+
+	mockServer := httptest.NewServer(mux)
+	defer mockServer.Close()
+	providerConfig := providerConfig(&mockServer.URL)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: *providerConfig + `resource "statuspal_status_page" "test" {
+					organization_id = "1"
+					status_page = {
+						name      = "Bunny Domain Test"
+						url       = "bunny.test"
+						time_zone = "UTC"
+						domain_config = {
+							provider = "bunny"
+							domain   = "bunny-test.example.com"
+						}
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("statuspal_status_page.test", "status_page.domain_config.provider", "bunny"),
+					resource.TestCheckResourceAttr("statuspal_status_page.test", "status_page.domain_config.domain", "bunny-test.example.com"),
+					resource.TestCheckResourceAttr("statuspal_status_page.test", "status_page.domain_config.main_hostname", "statuspal-eu-12345.b-cdn.net"),
+					resource.TestCheckResourceAttr("statuspal_status_page.test", "status_page.domain_config.pullzone_id", "12345"),
+					resource.TestCheckResourceAttr("statuspal_status_page.test", "status_page.domain_config.validation_records.cname.name", "bunny-test.example.com"),
+					resource.TestCheckResourceAttr("statuspal_status_page.test", "status_page.domain_config.validation_records.cname.value", "statuspal-eu-12345.b-cdn.net"),
+				),
+			},
+		},
+		CheckDestroy: func(s *terraform.State) error {
+			if pollCount.Load() == 0 {
+				return fmt.Errorf("expected polling for Bunny CNAME value, but no GET requests were made")
+			}
+			return nil
+		},
+	})
+}


### PR DESCRIPTION
Bunny pull zone creation is asynchronous — the API initially returns an empty CNAME value, causing DNS record creation to fail on the first terraform apply. The provider now polls until the CNAME is available before returning from Create/Update.                                                                                                        
                                                                     
Also added Bunny custom domain example, updated docs to clarify statuspal_domain_ssl_records is CloudFlare-only, fixed golangci-lint errcheck errors, and bumped to v0.4.2.
                                                                                                                        
  Test plan                                                          

  - All 16 tests pass (including new TestAccStatusPageResource_BunnyDomain)                                             
  - golangci-lint and terraform fmt clean
  - E2E: Bunny domain provisioned (bunny-test-2.messuti.io, EU)                                                         
  - E2E: CloudFlare domain provisioned (cf-regression.messuti.io, US) — regression test