### PR TITLE
[NXT-805] FIX: Raise Bunny pull zone poll timeout from 60s to 10m

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ website/vendor
 
 # Local-only e2e test harness (not for the repo)
 e2e-test-update/
+e2e-test-bunny/
+e2e-test-legacy-to-custom/
+
+# Compiled provider binary (output of `go build .`)
+/terraform-provider-statuspal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes of the StatusPal Terraform provider will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-06-22
+
+### Fixed
+
+- Bunny custom domain provisioning no longer fails with a "timed out waiting for
+  Bunny pull zone CNAME value after 1m0s" error during `terraform apply`. Because
+  the pull zone is created asynchronously, the provider now waits up to 10 minutes
+  (previously 60 seconds) for the CNAME value to become available, which prevents
+  the status page's custom domain from being left in a disabled state.
+
 ## [0.4.2] - 2026-05-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the pull zone is created asynchronously, the provider now waits up to 10 minutes
   (previously 60 seconds) for the CNAME value to become available, which prevents
   the status page's custom domain from being left in a disabled state.
+- The Bunny pull zone poll now honors cancellation: a cancelled `terraform apply`
+  or provider shutdown exits the poll promptly instead of blocking until the
+  timeout elapses.
 
 ## [0.4.2] - 2026-05-06
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     statuspal = {
       source  = "statuspal/statuspal"
-      version = "0.4.2"
+      version = "0.4.3"
     }
   }
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     statuspal = {
       source  = "statuspal/statuspal"
-      version = "0.4.2"
+      version = "0.4.3"
     }
   }
 

--- a/internal/provider/status_page_resource.go
+++ b/internal/provider/status_page_resource.go
@@ -25,6 +25,17 @@ import (
 	statuspal "terraform-provider-statuspal/internal/client"
 )
 
+const (
+	// Bunny pull zone creation is asynchronous: the backend enqueues a job that
+	// calls Bunny and only then writes back the CNAME value. That work can take
+	// well over a minute (the backend's own Bunny calls have multi-minute
+	// timeouts), so we poll generously. A short timeout here causes the apply to
+	// fail and leave the custom domain in a disabled state even though the
+	// backend completes the setup moments later.
+	bunnyPullZonePollInterval = 2 * time.Second
+	bunnyPullZoneTimeout      = 10 * time.Minute
+)
+
 var validationRecordAttrTypes = map[string]attr.Type{
 	"name":  types.StringType,
 	"type":  types.StringType,
@@ -759,7 +770,7 @@ func (r *statusPageResource) Create(ctx context.Context, req resource.CreateRequ
 	// Bunny pull zone creation is asynchronous — poll until the CNAME value is available.
 	if newStatusPage.DomainConfig != nil && newStatusPage.DomainConfig.CDNProvider != nil &&
 		strings.ToLower(*newStatusPage.DomainConfig.CDNProvider) == "bunny" {
-		newStatusPage, err = pollBunnyValidationRecords(r.client, organizationID, newStatusPage.Subdomain, 60*time.Second)
+		newStatusPage, err = pollBunnyValidationRecords(r.client, organizationID, newStatusPage.Subdomain, bunnyPullZoneTimeout)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error waiting for Bunny pull zone",
@@ -889,7 +900,7 @@ func (r *statusPageResource) Update(ctx context.Context, req resource.UpdateRequ
 		if updatedSubdomain == "" {
 			updatedSubdomain = subdomain
 		}
-		updatedStatusPage, err = pollBunnyValidationRecords(r.client, organizationID, updatedSubdomain, 60*time.Second)
+		updatedStatusPage, err = pollBunnyValidationRecords(r.client, organizationID, updatedSubdomain, bunnyPullZoneTimeout)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error waiting for Bunny pull zone",
@@ -1044,7 +1055,7 @@ func pollBunnyValidationRecords(
 		if time.Now().After(deadline) {
 			return sp, fmt.Errorf("timed out waiting for Bunny pull zone CNAME value after %s", timeout)
 		}
-		time.Sleep(2 * time.Second)
+		time.Sleep(bunnyPullZonePollInterval)
 	}
 }
 

--- a/internal/provider/status_page_resource.go
+++ b/internal/provider/status_page_resource.go
@@ -770,7 +770,7 @@ func (r *statusPageResource) Create(ctx context.Context, req resource.CreateRequ
 	// Bunny pull zone creation is asynchronous — poll until the CNAME value is available.
 	if newStatusPage.DomainConfig != nil && newStatusPage.DomainConfig.CDNProvider != nil &&
 		strings.ToLower(*newStatusPage.DomainConfig.CDNProvider) == "bunny" {
-		newStatusPage, err = pollBunnyValidationRecords(r.client, organizationID, newStatusPage.Subdomain, bunnyPullZoneTimeout)
+		newStatusPage, err = pollBunnyValidationRecords(ctx, r.client, organizationID, newStatusPage.Subdomain, bunnyPullZoneTimeout)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error waiting for Bunny pull zone",
@@ -900,7 +900,7 @@ func (r *statusPageResource) Update(ctx context.Context, req resource.UpdateRequ
 		if updatedSubdomain == "" {
 			updatedSubdomain = subdomain
 		}
-		updatedStatusPage, err = pollBunnyValidationRecords(r.client, organizationID, updatedSubdomain, bunnyPullZoneTimeout)
+		updatedStatusPage, err = pollBunnyValidationRecords(ctx, r.client, organizationID, updatedSubdomain, bunnyPullZoneTimeout)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error waiting for Bunny pull zone",
@@ -1027,12 +1027,19 @@ func needsLegacyDomainClear(ctx *context.Context, stateStatusPage *statusPageMod
 // configured and the CNAME value is populated. Bunny pull zone creation is
 // asynchronous, so the initial response may have an empty CNAME value.
 func pollBunnyValidationRecords(
+	ctx context.Context,
 	client *statuspal.Client,
 	orgID, subdomain string,
 	timeout time.Duration,
 ) (*statuspal.StatusPage, error) {
 	deadline := time.Now().Add(timeout)
 	for {
+		// Exit promptly if the apply was cancelled (e.g. Ctrl+C) or the provider
+		// is shutting down, rather than blocking until the full timeout elapses.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		sp, err := client.GetStatusPage(&orgID, &subdomain)
 		if err != nil {
 			return nil, err
@@ -1055,7 +1062,12 @@ func pollBunnyValidationRecords(
 		if time.Now().After(deadline) {
 			return sp, fmt.Errorf("timed out waiting for Bunny pull zone CNAME value after %s", timeout)
 		}
-		time.Sleep(bunnyPullZonePollInterval)
+
+		select {
+		case <-ctx.Done():
+			return sp, ctx.Err()
+		case <-time.After(bunnyPullZonePollInterval):
+		}
 	}
 }
 


### PR DESCRIPTION
The status page Create/Update poll waited only 60s for the Bunny pull-zone CNAME value, which the backend writes asynchronously and often takes longer to produce. On timeout the apply failed and left the custom domain disabled.

Raise to a generous 10m and extract the poll interval/timeout into named constants.

**QA-notes:**
tested end-to-end by applying test Terraform configs and provisioning an actual Bunny custom domain