### PR TITLE
[NXT-813] FIX: Omit server-managed domain_config fields from provider requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ website/vendor
 # Local-only e2e test harness (not for the repo)
 e2e-test-update/
 e2e-test-bunny/
+e2e-test-bunny-reapply/
 e2e-test-legacy-to-custom/
 
 # Compiled provider binary (output of `go build .`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes of the StatusPal Terraform provider will be documented in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2026-06-23
+
+### Fixed
+
+- The provider no longer sends the server-managed `domain_config` fields
+  (`main_hostname`, `pullzone_id`, `external_id`, `status`, `validation_records`,
+  `error`) as `null` on update. Re-applying a status page with an active custom
+  domain previously transmitted these computed fields as `null`, which could wipe
+  the live Bunny/Cloudflare linkage on the StatusPal side and leave the domain
+  disabled. They are now omitted from the request body.
+
 ## [0.4.3] - 2026-06-22
 
 ### Fixed

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     statuspal = {
       source  = "statuspal/statuspal"
-      version = "0.4.3"
+      version = "0.4.4"
     }
   }
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     statuspal = {
       source  = "statuspal/statuspal"
-      version = "0.4.3"
+      version = "0.4.4"
     }
   }
 

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -1,15 +1,22 @@
 package statuspal
 
 // DomainConfig represents the custom domain configuration for a status page.
+//
+// Only `provider` and `domain` are client-controllable. The remaining fields are
+// server-managed (computed) and must NOT be sent on create/update — `omitempty`
+// keeps nil pointers out of the request body so a re-apply doesn't transmit them
+// as `null`, which the backend would otherwise persist and wipe the live linkage
+// (see NXT-813). `omitempty` only affects marshalling; response unmarshalling is
+// unchanged.
 type DomainConfig struct {
 	CDNProvider       *string           `json:"provider"`
 	Domain            *string           `json:"domain"`
-	MainHostname      *string           `json:"main_hostname"`
-	ValidationRecords map[string]string `json:"validation_records"`
-	ExternalID        *string           `json:"external_id"`
-	Status            *string           `json:"status"`
-	Error             *string           `json:"error"`
-	PullzoneID        *int64            `json:"pullzone_id"`
+	MainHostname      *string           `json:"main_hostname,omitempty"`
+	ValidationRecords map[string]string `json:"validation_records,omitempty"`
+	ExternalID        *string           `json:"external_id,omitempty"`
+	Status            *string           `json:"status,omitempty"`
+	Error             *string           `json:"error,omitempty"`
+	PullzoneID        *int64            `json:"pullzone_id,omitempty"`
 }
 
 // StatusPage struct.


### PR DESCRIPTION
Hardens the Terraform provider so it no longer sends the server-managed domain_config fields (main_hostname, pullzone_id, external_id, status, validation_records, error) as null on update. Previously, re-applying a status page with an active Bunny/Cloudflare custom domain transmitted these computed fields as null, which the StatusPal backend would persist and wipe the live domain linkage, leaving the domain stuck in a disabled state. Adding omitempty keeps the nil pointers out of the request body (marshalling-only; response parsing is unchanged). Bumps the provider to v0.4.4 with a changelog entry. This is a defense-in-depth complement to the primary fix on the StatusPal backend.